### PR TITLE
Fix redundant field names

### DIFF
--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -46,8 +46,8 @@ impl AppInfo {
     /// Construct an `AppInfo` instance from API id and API hash.
     pub fn new(api_id: i32, api_hash: String) -> AppInfo {
         AppInfo {
-            api_id: api_id,
-            api_hash: api_hash,
+            api_id,
+            api_hash,
         }
     }
 


### PR DESCRIPTION
Specifying field names is not necessary in this situation.